### PR TITLE
Fix attributes description

### DIFF
--- a/ckanext/datajson/package2pod.py
+++ b/ckanext/datajson/package2pod.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+    #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 try:

--- a/ckanext/datajson/package2pod.py
+++ b/ckanext/datajson/package2pod.py
@@ -1,4 +1,4 @@
-    #!/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 try:

--- a/ckanext/datajson/plugin.py
+++ b/ckanext/datajson/plugin.py
@@ -182,9 +182,12 @@ class DataJsonController(BaseController):
                         packages[i]['extras'][j]['value'] = json.loads(extra['value'])
                     j += 1
                 try:
-                    for j in range(0, len(packages[i]['resources'])):
-                        fixed_attrDesc = json.loads(packages[i]['resources'][j]['attributesDescription'])
-                        packages[i]['resources'][j]['attributesDescription'] = fixed_attrDesc
+                    for index, resource in enumerate(packages[i]['resources']):
+                        try:
+                            fixed_attrDesc = json.loads(resource['attributesDescription'])
+                            packages[i]['resources'][index]['attributesDescription'] = fixed_attrDesc
+                        except ValueError:
+                            logger.error('Fallo rendere de \'attributesDescription\'.')
                 except KeyError:
                     pass
                 try:

--- a/ckanext/datajson/plugin.py
+++ b/ckanext/datajson/plugin.py
@@ -187,7 +187,7 @@ class DataJsonController(BaseController):
                             fixed_attrDesc = json.loads(resource['attributesDescription'])
                             packages[i]['resources'][index]['attributesDescription'] = fixed_attrDesc
                         except ValueError:
-                            logger.error('Fallo rendere de \'attributesDescription\'.')
+                            logger.error('Fallo render de \'attributesDescription\'.')
                 except KeyError:
                     pass
                 try:


### PR DESCRIPTION
Si al cargar un nuevo recurso por la GUI o API, no se completan los campos de **Documentación del recurso**, se rompe el renderizado del */data.json* arrando una respuesta vacia **" "**.
Dichos campos **no son requeridos**.